### PR TITLE
fixing api changes needed to work  with 2.16.2

### DIFF
--- a/lib/guard/slim.rb
+++ b/lib/guard/slim.rb
@@ -1,11 +1,11 @@
 require "guard"
-require "guard/guard"
 require "guard/watcher"
 require "slim"
 require "fileutils"
+require "guard/compat/plugin"
 
 module Guard
-  class Slim < Guard
+  class Slim < Plugin
     NullContext = Struct.new(:template)
 
     DEFAULTS = {
@@ -23,9 +23,9 @@ module Guard
     # @param [Hash] options
     #   the plugin options
     #
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       options = DEFAULTS.merge(options)
-      super(watchers, options)
+      super(options)
     end
 
     # Called once when Guard starts

--- a/lib/guard/slim/template.rb
+++ b/lib/guard/slim/template.rb
@@ -1,5 +1,7 @@
+require 'guard/slim'
+
 module Guard
-  class Slim < Guard
+  class Slim < Plugin
     class Template < Struct.new(:path)
     end
   end

--- a/lib/guard/slim/template_renderer.rb
+++ b/lib/guard/slim/template_renderer.rb
@@ -1,5 +1,5 @@
 module Guard
-  class Slim < Guard
+  class Slim < Plugin
     class TemplateRenderer
       # Initializes a template renderer
       #


### PR DESCRIPTION
API changes with the Guard gem have broken the compatibility of this gem. These are the minor changes needed to make it functional again. This follows the same pattern to address these changes used by Guard::Bundler.